### PR TITLE
エクスプローラ上でのフォルダへの移動機能APIを実装

### DIFF
--- a/app/components/folder-explorer/FileLink.tsx
+++ b/app/components/folder-explorer/FileLink.tsx
@@ -35,9 +35,7 @@ export default function FileLink({ targetTerm, isActive, selectable }: Props) {
       <span className={styles.label}>
         {isActive && activeTermTitle ? activeTermTitle : targetTerm.name}
       </span>
-      {selectable && (
-        <EntryCheckbox type="file" onChange={() => updateCheckedFile(targetTerm.id)} />
-      )}
+      {selectable && <EntryCheckbox type="file" onChange={() => updateCheckedFile(targetTerm)} />}
     </Tag>
   )
 }

--- a/app/components/folder-explorer/FolderExplorer.tsx
+++ b/app/components/folder-explorer/FolderExplorer.tsx
@@ -84,6 +84,7 @@ export default function FolderExplorer({ initials, pathFolderIds, currentTermId 
             <li key={folder.id}>
               <FolderLink
                 onLinkClick={() => setFolderId(folder.id)}
+                currentTermId={currentTermId}
                 folder={folder}
                 folderEntryCount={folder.entry_count}
                 isActiveStyle={pathFolderIds.has(folder.id)}

--- a/app/components/folder-explorer/FolderLink.tsx
+++ b/app/components/folder-explorer/FolderLink.tsx
@@ -13,6 +13,7 @@ import {
 } from "~/usecases/folder-explorer/move-to-folder/ui.hooks"
 import { notifications } from "@mantine/notifications"
 import { errorContent, successContent } from "~/libs/mantine-notifications/options"
+import LoadingLabel from "../loading-label/LoadingLabel"
 
 interface Props {
   currentTermId: number
@@ -57,7 +58,9 @@ export default function FolderLink({
           }}
           disabled={selectedCount === 0 || isMoving}
           loading={isMoving}
-          loaderProps={{ type: "dots" }}
+          loaderProps={{
+            children: <LoadingLabel doing="Moving" iconSize={14} />
+          }}
           onClick={() => {
             execMoveApi({
               onSuccess: ({ message }) => {

--- a/app/components/folder-explorer/FolderLink.tsx
+++ b/app/components/folder-explorer/FolderLink.tsx
@@ -15,6 +15,7 @@ import { notifications } from "@mantine/notifications"
 import { errorContent, successContent } from "~/libs/mantine-notifications/options"
 
 interface Props {
+  currentTermId: number
   folder: { id: number; name: string }
   folderEntryCount: number
   isActiveStyle: boolean
@@ -24,6 +25,7 @@ interface Props {
 }
 
 export default function FolderLink({
+  currentTermId,
   folder,
   folderEntryCount,
   isActiveStyle,
@@ -32,7 +34,7 @@ export default function FolderLink({
   selectedCount
 }: Props) {
   const [isOpenedContextMenu, setIsOpenedContextMenu] = useState(false)
-  const { destFolder, setDestFolder, execMoveApi, isMoving } = useMoveToFolderUi()
+  const { destFolder, setDestFolder, execMoveApi, isMoving } = useMoveToFolderUi(currentTermId)
   const { updateCheckedFolder } = useCheckFolderToMoveUi()
   const isEmpty = folderEntryCount === 0
 

--- a/app/components/folder-explorer/FolderLink.tsx
+++ b/app/components/folder-explorer/FolderLink.tsx
@@ -11,6 +11,8 @@ import {
   useCheckFolderToMoveUi,
   useMoveToFolderUi
 } from "~/usecases/folder-explorer/move-to-folder/ui.hooks"
+import { notifications } from "@mantine/notifications"
+import { errorContent, successContent } from "~/libs/mantine-notifications/options"
 
 interface Props {
   folder: { id: number; name: string }
@@ -30,7 +32,7 @@ export default function FolderLink({
   selectedCount
 }: Props) {
   const [isOpenedContextMenu, setIsOpenedContextMenu] = useState(false)
-  const { destFolder, setDestFolder } = useMoveToFolderUi()
+  const { destFolder, setDestFolder, execMoveApi } = useMoveToFolderUi()
   const { updateCheckedFolder } = useCheckFolderToMoveUi()
   const isEmpty = folderEntryCount === 0
 
@@ -52,6 +54,18 @@ export default function FolderLink({
             label: { fontSize: "0.7rem" }
           }}
           disabled={selectedCount === 0}
+          onClick={() => {
+            execMoveApi({
+              onSuccess: ({ message }) => {
+                notifications.show(successContent(message))
+              },
+              onError: ({ errors }) => {
+                errors.forEach(({ message }) => {
+                  notifications.show(errorContent(message))
+                })
+              }
+            })
+          }}
         >
           Move Here
         </Button>

--- a/app/components/folder-explorer/FolderLink.tsx
+++ b/app/components/folder-explorer/FolderLink.tsx
@@ -63,12 +63,18 @@ export default function FolderLink({
           }}
           onClick={() => {
             execMoveApi({
-              onSuccess: ({ message }) => {
-                notifications.show(successContent(message))
+              onSuccess: ({ messages }) => {
+                messages.forEach(({ text, type }) => {
+                  const content =
+                    type === "success"
+                      ? successContent(text)
+                      : errorContent(text, null, { autoClose: true })
+                  notifications.show(content)
+                })
               },
               onError: ({ details }) => {
                 details.forEach(({ message }) => {
-                  notifications.show(errorContent(message))
+                  notifications.show(errorContent(message, null, { autoClose: true }))
                 })
               }
             })

--- a/app/components/folder-explorer/FolderLink.tsx
+++ b/app/components/folder-explorer/FolderLink.tsx
@@ -72,7 +72,7 @@ export default function FolderLink({
           Move Here
         </Button>
       ) : (
-        <EntryCheckbox type="folder" onChange={() => updateCheckedFolder(folder.id)} />
+        <EntryCheckbox type="folder" onChange={() => updateCheckedFolder(folder)} />
       )}
     </div>
   ) : (

--- a/app/components/folder-explorer/FolderLink.tsx
+++ b/app/components/folder-explorer/FolderLink.tsx
@@ -9,7 +9,7 @@ import MenuItemForMove from "./folder-context-menu/MenuItemForMove"
 import MenuItemForRename from "./folder-context-menu/MenuItemForRename"
 import {
   useCheckFolderToMoveUi,
-  useMovingTargetFolderUi
+  useMoveToFolderUi
 } from "~/usecases/folder-explorer/move-to-folder/ui.hooks"
 
 interface Props {
@@ -30,7 +30,7 @@ export default function FolderLink({
   selectedCount
 }: Props) {
   const [isOpenedContextMenu, setIsOpenedContextMenu] = useState(false)
-  const { destinationFolderId, setDestinationFolderId } = useMovingTargetFolderUi()
+  const { destFolder, setDestFolder } = useMoveToFolderUi()
   const { updateCheckedFolder } = useCheckFolderToMoveUi()
   const isEmpty = folderEntryCount === 0
 
@@ -38,7 +38,7 @@ export default function FolderLink({
     <div className={clsx(styles.entry_link, styles.folder_link, styles.selectable)}>
       <IconFolderFilled size={18} className={styles.entry_icon} />
       <span className={styles.label}>{folder.name}</span>
-      {destinationFolderId === folder.id ? (
+      {destFolder?.id === folder.id ? (
         <Button
           variant="outline"
           color="pink"
@@ -98,9 +98,9 @@ export default function FolderLink({
       <Menu.Dropdown>
         <MenuItemForRename />
         <MenuItemForMove
-          folderId={folder.id}
+          folder={folder}
           closeMenu={() => setIsOpenedContextMenu(false)}
-          setDestinationFolderId={setDestinationFolderId}
+          setDestFolder={setDestFolder}
         />
         <Menu.Divider />
         <MenuItemForDelete

--- a/app/components/folder-explorer/FolderLink.tsx
+++ b/app/components/folder-explorer/FolderLink.tsx
@@ -66,8 +66,8 @@ export default function FolderLink({
               onSuccess: ({ message }) => {
                 notifications.show(successContent(message))
               },
-              onError: ({ errors }) => {
-                errors.forEach(({ message }) => {
+              onError: ({ details }) => {
+                details.forEach(({ message }) => {
                   notifications.show(errorContent(message))
                 })
               }

--- a/app/components/folder-explorer/FolderLink.tsx
+++ b/app/components/folder-explorer/FolderLink.tsx
@@ -32,7 +32,7 @@ export default function FolderLink({
   selectedCount
 }: Props) {
   const [isOpenedContextMenu, setIsOpenedContextMenu] = useState(false)
-  const { destFolder, setDestFolder, execMoveApi } = useMoveToFolderUi()
+  const { destFolder, setDestFolder, execMoveApi, isMoving } = useMoveToFolderUi()
   const { updateCheckedFolder } = useCheckFolderToMoveUi()
   const isEmpty = folderEntryCount === 0
 
@@ -53,7 +53,9 @@ export default function FolderLink({
             section: { margin: 0 },
             label: { fontSize: "0.7rem" }
           }}
-          disabled={selectedCount === 0}
+          disabled={selectedCount === 0 || isMoving}
+          loading={isMoving}
+          loaderProps={{ type: "dots" }}
           onClick={() => {
             execMoveApi({
               onSuccess: ({ message }) => {

--- a/app/components/folder-explorer/folder-context-menu/MenuItemForMove.tsx
+++ b/app/components/folder-explorer/folder-context-menu/MenuItemForMove.tsx
@@ -2,17 +2,17 @@ import { Menu } from "@mantine/core"
 import { IconLogin2 } from "@tabler/icons-react"
 
 interface Props {
-  folderId: number
+  folder: { id: number | null; name: string }
   closeMenu: () => void
-  setDestinationFolderId: (id: number) => void
+  setDestFolder: (folder: { id: number | null; name: string }) => void
 }
 
-export default function MenuItemForMove({ folderId, closeMenu, setDestinationFolderId }: Props) {
+export default function MenuItemForMove({ folder, closeMenu, setDestFolder }: Props) {
   return (
     <Menu.Item
       leftSection={<IconLogin2 size={16} />}
       onClick={() => {
-        setDestinationFolderId(folderId)
+        setDestFolder(folder)
         closeMenu()
       }}
     >

--- a/app/components/folder-path/FolderPath.tsx
+++ b/app/components/folder-path/FolderPath.tsx
@@ -1,14 +1,18 @@
 import { IconFolder } from "@tabler/icons-react"
 import styles from "./FolderPath.module.css"
+import { useTermPath } from "~/queries/term-path/ui.hooks"
 
 interface Props {
-  folders: { id: number; name: string }[]
+  termId: number
+  initialPath?: { id: number; name: string }[]
 }
 
-export default function FolderPath({ folders }: Props) {
-  return folders.length > 0 ? (
+export default function FolderPath({ termId, initialPath }: Props) {
+  const { paths } = useTermPath(termId, initialPath ?? [])
+
+  return paths.length > 0 ? (
     <ul className={styles.list}>
-      {folders.map((folder) => (
+      {paths.map((folder) => (
         <li key={folder.id} className={styles.list_item}>
           <div className={styles.item_inner}>
             <IconFolder size={12} />

--- a/app/components/loading-label/LoadingLabel.module.css
+++ b/app/components/loading-label/LoadingLabel.module.css
@@ -1,5 +1,6 @@
 .loading {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.25em;
+  color: var(--loader-color);
 }

--- a/app/components/loading-label/LoadingLabel.tsx
+++ b/app/components/loading-label/LoadingLabel.tsx
@@ -1,0 +1,16 @@
+import IconLoadingSpinner from "../icon-loading-spinner/IconLoadingSpinner"
+import loadingStyle from "./LoadingLabel.module.css"
+
+interface Props {
+  doing: string
+  iconSize?: string | number
+}
+
+export default function LoadingLabel({ doing, iconSize = "16px" }: Props) {
+  return (
+    <span className={loadingStyle.loading}>
+      <IconLoadingSpinner size={iconSize} />
+      {doing}...
+    </span>
+  )
+}

--- a/app/components/term-save-button/SaveButton.tsx
+++ b/app/components/term-save-button/SaveButton.tsx
@@ -3,11 +3,10 @@ import { useCurrentEditor } from "@tiptap/react"
 import { type ButtonHTMLAttributes } from "react"
 import { useParams } from "react-router"
 import { notifications } from "@mantine/notifications"
-import loadingStyle from "./loading.module.css"
 import { useTermContentSaveUi } from "~/usecases/term-edit/ui.hooks"
-import IconLoadingSpinner from "../icon-loading-spinner/IconLoadingSpinner"
 import { errorContent, successContent, warningContent } from "~/libs/mantine-notifications/options"
 import { getMainContentFromDoc } from "~/libs/tiptap-editor/utils"
+import LoadingLabel from "../loading-label/LoadingLabel"
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {}
 
@@ -23,6 +22,8 @@ const SaveButton = (props: Props) => {
       gradient={{ from: "grape", to: "indigo", deg: 90 }}
       radius="sm"
       disabled={!isCanSave || isSaving}
+      loading={isSaving}
+      loaderProps={{ children: <LoadingLabel doing="Saving" iconSize={16} /> }}
       onClick={() => {
         if (!editor) return
 
@@ -51,14 +52,7 @@ const SaveButton = (props: Props) => {
       }}
       {...props}
     >
-      {isSaving ? (
-        <span className={loadingStyle.loading}>
-          <IconLoadingSpinner size="16px" />
-          Saving...
-        </span>
-      ) : (
-        "Save"
-      )}
+      Save
     </Button>
   )
 }

--- a/app/libs/mantine-notifications/options.ts
+++ b/app/libs/mantine-notifications/options.ts
@@ -15,10 +15,14 @@ export const warningContent = (message: ReactNode) => ({
   classNames: styles
 })
 
-export const errorContent = (message: ReactNode, target?: string) => ({
+export const errorContent = (
+  message: ReactNode,
+  target?: string | null,
+  { autoClose = false } = {}
+) => ({
   title: target ? `ERROR: ${target}` : "ERROR",
   message,
   color: "pink",
   classNames: styles,
-  autoClose: false
+  autoClose
 })

--- a/app/queries/folder-detail/reader.server.ts
+++ b/app/queries/folder-detail/reader.server.ts
@@ -6,11 +6,6 @@ export const getFolder = async (folderId: number | null) => {
   return FolderService.getFolder(folderId)
 }
 
-export const getFolderPath = async (folderId: number | null) => {
-  if (folderId === null) return null
-  return FolderService.getFolderPath(folderId)
-}
-
 export const getFolderChildren = async (folderId: number | null) => {
   const [folders, files] = await Promise.all([
     FolderChildrenReadStore.findChildrenFolders(folderId),

--- a/app/queries/term-path/reader.server.ts
+++ b/app/queries/term-path/reader.server.ts
@@ -1,0 +1,8 @@
+import * as FolderService from "~/units/folder/service.server"
+import * as TermService from "~/units/term/service.server"
+
+export const getTermPath = async (termId: number) => {
+  const folderId = await TermService.getTermParentFolderId(termId)
+  if (folderId === null) return []
+  return FolderService.getFolderPath(folderId)
+}

--- a/app/queries/term-path/ui.hooks.ts
+++ b/app/queries/term-path/ui.hooks.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query"
+import { termKeys } from "~/query-keys"
+
+export const useTermPath = (termId: number, initials: { id: number; name: string }[]) => {
+  const { data, isPending, isError } = useQuery<{ id: number; name: string }[]>({
+    queryKey: termKeys.path(termId),
+    queryFn: () => fetch(`/api/terms/${termId}/path`).then((res) => res.json()),
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+    placeholderData: initials
+  })
+
+  return { paths: data ?? [], isPending, isError }
+}

--- a/app/query-keys.ts
+++ b/app/query-keys.ts
@@ -4,6 +4,7 @@ export const termKeys = {
   all: ["terms"] as const,
   details: () => [...termKeys.all, "detail"] as const,
   detail: (id: number) => [...termKeys.details(), id] as const,
+  path: (id: number) => [...termKeys.detail(id), "path"] as const,
   preview: (id: number) => [...termKeys.detail(id), "preview"] as const
 }
 

--- a/app/query-keys.ts
+++ b/app/query-keys.ts
@@ -10,6 +10,6 @@ export const termKeys = {
 export const folderKeys = {
   all: ["folders"] as const,
   details: () => [...folderKeys.all, "detail"] as const,
-  detail: (id: string) => [...folderKeys.details(), id] as const,
-  children: (id: string) => [...folderKeys.detail(id), "children"] as const
+  detail: (id: number | string) => [...folderKeys.details(), id] as const,
+  children: (id: number | string) => [...folderKeys.detail(id), "children"] as const
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,6 +13,9 @@ export default [
     route("folders/:folderId/children", "routes/api/folders/children.ts"),
     route("folders/:folderId/rename", "routes/api/folders/rename.ts"),
     route("folders/new", "routes/api/folders/new.ts"),
-    route("folders/:folderId/delete", "routes/api/folders/delete.ts")
+    route("folders/:folderId/delete", "routes/api/folders/delete.ts"),
+
+    //route("entries/new", "routes/api/entries/new.ts"), // TODO: folders/newを改名
+    route("entries/move", "routes/api/entries/move.ts")
   ])
 ] satisfies RouteConfig

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -6,6 +6,7 @@ export default [
   route("folder-map", "routes/folder-map.tsx"),
 
   ...prefix("api", [
+    route("terms/:termId/path", "routes/api/terms/path.ts"),
     route("terms/:termId/preview", "routes/api/terms/preview.ts"),
     route("terms/:termId/edit", "routes/api/terms/edit.ts"),
     route("terms/:termId/delete", "routes/api/terms/delete.ts"),

--- a/app/routes/api/entries/move.ts
+++ b/app/routes/api/entries/move.ts
@@ -1,7 +1,25 @@
-import { data } from "react-router"
 import type { Route } from "./+types/move"
 import { delay } from "~/libs/debug"
 import { moveEntriesIntoSubfolder } from "~/usecases/folder-explorer/move-to-folder/feature.server"
+import type { EntriesResults } from "~/usecases/folder-explorer/move-to-folder/types"
+
+const entryLabel = (type: "file" | "folder") => (type === "file" ? "ノート" : "フォルダ")
+
+const successMessage = (type: "file" | "folder", entry: EntriesResults, parentName: string) => {
+  const { count, names } = entry
+  return `${count}件の${entryLabel(type)}を「${parentName}」に移動しました: ${names.join(", ")}`
+}
+
+const failureMessage = (type: "file" | "folder", entry: EntriesResults) => {
+  const { count, names } = entry
+  return `${count}件の${entryLabel(type)}の移動に失敗しました: ${names.join(", ")}`
+}
+
+interface MoveActionResponse {
+  messages: { type: "error" | "success"; text: string }[]
+  success: { file: number[]; folder: number[] }
+  errorsCount: number
+}
 
 export async function action({ request }: Route.ActionArgs) {
   const requestData = await request.json()
@@ -12,17 +30,26 @@ export async function action({ request }: Route.ActionArgs) {
 
   const result = await moveEntriesIntoSubfolder({ targets, newParentId: newParent.id })
 
-  if (!result.ok) {
-    const errors = result.rejected.flatMap((r) => {
-      return r.type === "folder"
-        ? { message: "フォルダの移動に失敗しました: " + r.names.join(", ") }
-        : { message: "ノートの移動に失敗しました: " + r.names.join(", ") }
-    })
+  return result.details.reduce<MoveActionResponse>(
+    (acc, detail) => {
+      if (detail.count === 0) return acc
 
-    return data(errors, { status: 500 })
-  }
+      if (detail.status === "SUCCESS") {
+        acc.messages.push({
+          type: "success",
+          text: successMessage(detail.type, detail, newParent.name)
+        })
+        acc.success[detail.type] = detail.ids
+      } else {
+        acc.messages.push({
+          type: "error",
+          text: failureMessage(detail.type, detail)
+        })
+        acc.errorsCount += detail.count
+      }
 
-  const countMoved = result.files.length + result.folders.length
-
-  return { ...result, message: `${countMoved}件のアイテムを「${newParent.name}」に移動しました。` }
+      return acc
+    },
+    { messages: [], errorsCount: 0, success: { file: [], folder: [] } }
+  )
 }

--- a/app/routes/api/entries/move.ts
+++ b/app/routes/api/entries/move.ts
@@ -1,3 +1,4 @@
+import { data } from "react-router"
 import type { Route } from "./+types/move"
 import { delay } from "~/libs/debug"
 import { moveEntriesIntoSubfolder } from "~/usecases/folder-explorer/move-to-folder/feature.server"
@@ -18,7 +19,7 @@ export async function action({ request }: Route.ActionArgs) {
         : { message: "ノートの移動に失敗しました: " + r.name }
     })
 
-    return { errors, status: 500 }
+    return data(errors, { status: 500 })
   }
 
   const countMoved = result.files.length + result.folders.length

--- a/app/routes/api/entries/move.ts
+++ b/app/routes/api/entries/move.ts
@@ -1,0 +1,27 @@
+import type { Route } from "./+types/move"
+import { delay } from "~/libs/debug"
+import { moveEntriesIntoSubfolder } from "~/usecases/folder-explorer/move-to-folder/feature.server"
+
+export async function action({ request }: Route.ActionArgs) {
+  const requestData = await request.json()
+  const { targets, newParent } = requestData
+
+  // [for debug]
+  //await delay(5000)
+
+  const result = await moveEntriesIntoSubfolder({ targets, newParentId: newParent.id })
+
+  if (!result.ok) {
+    const errors = result.rejected.map((r) => {
+      return r.type === "folder"
+        ? { message: "フォルダの移動に失敗しました: " + r.name }
+        : { message: "ノートの移動に失敗しました: " + r.name }
+    })
+
+    return { errors, status: 500 }
+  }
+
+  const countMoved = result.files.length + result.folders.length
+
+  return { ...result, message: `${countMoved}件のアイテムを「${newParent.name}」に移動しました 🎉` }
+}

--- a/app/routes/api/entries/move.ts
+++ b/app/routes/api/entries/move.ts
@@ -13,10 +13,10 @@ export async function action({ request }: Route.ActionArgs) {
   const result = await moveEntriesIntoSubfolder({ targets, newParentId: newParent.id })
 
   if (!result.ok) {
-    const errors = result.rejected.map((r) => {
+    const errors = result.rejected.flatMap((r) => {
       return r.type === "folder"
-        ? { message: "フォルダの移動に失敗しました: " + r.name }
-        : { message: "ノートの移動に失敗しました: " + r.name }
+        ? { message: "フォルダの移動に失敗しました: " + r.names.join(", ") }
+        : { message: "ノートの移動に失敗しました: " + r.names.join(", ") }
     })
 
     return data(errors, { status: 500 })

--- a/app/routes/api/entries/move.ts
+++ b/app/routes/api/entries/move.ts
@@ -22,7 +22,8 @@ export async function action({ request }: Route.ActionArgs) {
     return data(errors, { status: 500 })
   }
 
-  const countMoved = result.files.length - 1 + (result.folders.length - 1)
+  console.log(result.files, result.folders)
+  const countMoved = result.files.length + result.folders.length
 
   return { ...result, message: `${countMoved}件のアイテムを「${newParent.name}」に移動しました。` }
 }

--- a/app/routes/api/entries/move.ts
+++ b/app/routes/api/entries/move.ts
@@ -24,5 +24,5 @@ export async function action({ request }: Route.ActionArgs) {
 
   const countMoved = result.files.length + result.folders.length
 
-  return { ...result, message: `${countMoved}件のアイテムを「${newParent.name}」に移動しました 🎉` }
+  return { ...result, message: `${countMoved}件のアイテムを「${newParent.name}」に移動しました。` }
 }

--- a/app/routes/api/entries/move.ts
+++ b/app/routes/api/entries/move.ts
@@ -22,7 +22,6 @@ export async function action({ request }: Route.ActionArgs) {
     return data(errors, { status: 500 })
   }
 
-  console.log(result.files, result.folders)
   const countMoved = result.files.length + result.folders.length
 
   return { ...result, message: `${countMoved}件のアイテムを「${newParent.name}」に移動しました。` }

--- a/app/routes/api/entries/move.ts
+++ b/app/routes/api/entries/move.ts
@@ -22,7 +22,7 @@ export async function action({ request }: Route.ActionArgs) {
     return data(errors, { status: 500 })
   }
 
-  const countMoved = result.files.length + result.folders.length
+  const countMoved = result.files.length - 1 + (result.folders.length - 1)
 
   return { ...result, message: `${countMoved}件のアイテムを「${newParent.name}」に移動しました。` }
 }

--- a/app/routes/api/terms/path.ts
+++ b/app/routes/api/terms/path.ts
@@ -1,0 +1,8 @@
+import { getTermPath } from "~/queries/term-path/reader.server"
+import type { Route } from "./+types/path"
+
+export async function loader({ params }: Route.ActionArgs) {
+  const paths = await getTermPath(Number(params.termId))
+
+  return paths
+}

--- a/app/routes/term.tsx
+++ b/app/routes/term.tsx
@@ -10,7 +10,7 @@ import type { Route } from "./+types/term"
 import RelatedTermView from "~/components/related-term-view/RelatedTermView"
 import RelatedInput from "~/components/related-input/RelatedInput"
 import FolderPath from "~/components/folder-path/FolderPath"
-import { getFolder, getFolderPath } from "~/queries/folder-detail/reader.server"
+import { getFolder } from "~/queries/folder-detail/reader.server"
 import EditorActionMenu from "~/components/editor-action-menu/EditorActionMenu"
 import { Split } from "@gfazioli/mantine-split-pane"
 import FolderExplorer from "~/components/folder-explorer/FolderExplorer"
@@ -21,6 +21,7 @@ import ScrollArea from "~/components/scroll-area/ScrollArea"
 import { getTermWithMeta } from "~/queries/term-detail/reader.server"
 import { getFolderChildren } from "~/queries/folder-detail/reader.server"
 import { getRelatedTermOptions } from "~/queries/term-list/reader.server"
+import { getTermPath } from "~/queries/term-path/reader.server"
 
 export async function loader({ params }: Route.LoaderArgs) {
   const { termId } = params
@@ -30,7 +31,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   const [entries, current, paths, relatedOptions] = await Promise.all([
     getFolderChildren(folderId),
     getFolder(folderId),
-    getFolderPath(folderId),
+    getTermPath(term.id),
     getRelatedTermOptions(term.id, folderId)
   ])
 
@@ -73,7 +74,7 @@ export default function Term({ loaderData }: Route.ComponentProps) {
       <React.Fragment key={location.pathname}>
         <EditorWith content={term.content} title={term.title} aliases={alias}>
           <div className="controls-area">
-            <FolderPath folders={paths} />
+            <FolderPath termId={term.id} initialPath={paths} />
             <EditorActionMenu />
           </div>
           <div className="save-area">

--- a/app/units/folder/repository.server.ts
+++ b/app/units/folder/repository.server.ts
@@ -1,4 +1,4 @@
-import { asc, eq, isNull, sql } from "drizzle-orm"
+import { asc, eq, isNull, sql, inArray } from "drizzle-orm"
 import { db } from "~/db/connection"
 import { folders } from "~/db/schema"
 
@@ -59,5 +59,13 @@ export const deleteById = async (folderId: number) => {
   return db
     .delete(folders)
     .where(eq(folders.id, folderId))
+    .returning({ id: folders.id, name: folders.name })
+}
+
+export const moveMany = async (folderIds: number[], newParentId: number | null) => {
+  return db
+    .update(folders)
+    .set({ parentId: newParentId })
+    .where(inArray(folders.id, folderIds))
     .returning({ id: folders.id, name: folders.name })
 }

--- a/app/units/folder/service.server.ts
+++ b/app/units/folder/service.server.ts
@@ -22,3 +22,8 @@ export const deleteFolder = async (folderId: number) => {
   const [deletedFolder] = await FolderRepository.deleteById(folderId)
   return deletedFolder
 }
+
+export const moveFolders = async (folderIds: number[], newParentId: number | null) => {
+  const [movedFolder] = await FolderRepository.moveMany(folderIds, newParentId)
+  return { type: "folder", ...movedFolder }
+}

--- a/app/units/folder/service.server.ts
+++ b/app/units/folder/service.server.ts
@@ -24,6 +24,7 @@ export const deleteFolder = async (folderId: number) => {
 }
 
 export const moveFolders = async (folderIds: number[], newParentId: number | null) => {
-  const [movedFolder] = await FolderRepository.moveMany(folderIds, newParentId)
-  return { type: "folder", ...movedFolder }
+  if (folderIds.length === 0) return []
+  const movedFolder = await FolderRepository.moveMany(folderIds, newParentId)
+  return movedFolder
 }

--- a/app/units/term/repository.server.ts
+++ b/app/units/term/repository.server.ts
@@ -1,6 +1,6 @@
 import { db } from "~/db/connection"
 import { terms } from "~/db/schema"
-import { eq, desc } from "drizzle-orm"
+import { eq, desc, inArray } from "drizzle-orm"
 import type { JSONContent } from "@tiptap/react"
 
 export const findAll = async () => {
@@ -51,5 +51,13 @@ export const createEmpty = async ({ title, folderId, content }: CreateData) => {
   return db
     .insert(terms)
     .values({ title, folderId, content })
+    .returning({ id: terms.id, title: terms.title })
+}
+
+export const moveMany = async (termIds: number[], newFolderId: number | null) => {
+  return db
+    .update(terms)
+    .set({ folderId: newFolderId })
+    .where(inArray(terms.id, termIds))
     .returning({ id: terms.id, title: terms.title })
 }

--- a/app/units/term/repository.server.ts
+++ b/app/units/term/repository.server.ts
@@ -30,6 +30,11 @@ export const findRecent = async ({ limit = 1 }) => {
   return rows
 }
 
+export const getParentFolderId = async (termId: number) => {
+  const rows = await db.select({ folderId: terms.folderId }).from(terms).where(eq(terms.id, termId))
+
+  return rows
+}
 interface UpdateContentData {
   title: string
   content: JSONContent

--- a/app/units/term/service.server.ts
+++ b/app/units/term/service.server.ts
@@ -19,6 +19,11 @@ export const getRecentTerm = async () => {
   return terms
 }
 
+export const getTermParentFolderId = async (termId: number) => {
+  const [term] = await TermRepository.getParentFolderId(termId)
+  return term?.folderId ?? null
+}
+
 export const updateTermContent = async (termId: number, title: string, content: JSONContent) => {
   return TermRepository.updateContent(termId, { title, content })
 }

--- a/app/units/term/service.server.ts
+++ b/app/units/term/service.server.ts
@@ -31,3 +31,8 @@ export const createEmptyTerm = async (title: string, folderId: number | null) =>
   })
   return { id: newTerm.id, name: newTerm.title }
 }
+
+export const moveTerms = async (termIds: number[], newFolderId: number | null) => {
+  const [movedTerm] = await TermRepository.moveMany(termIds, newFolderId)
+  return { type: "term", id: movedTerm.id, name: movedTerm.title }
+}

--- a/app/units/term/service.server.ts
+++ b/app/units/term/service.server.ts
@@ -38,6 +38,7 @@ export const createEmptyTerm = async (title: string, folderId: number | null) =>
 }
 
 export const moveTerms = async (termIds: number[], newFolderId: number | null) => {
-  const [movedTerm] = await TermRepository.moveMany(termIds, newFolderId)
-  return { type: "term", id: movedTerm.id, name: movedTerm.title }
+  if (termIds.length === 0) return []
+  const movedTerm = await TermRepository.moveMany(termIds, newFolderId)
+  return movedTerm.map((term) => ({ id: term.id, name: term.title }))
 }

--- a/app/usecases/folder-explorer/move-to-folder/feature.server.ts
+++ b/app/usecases/folder-explorer/move-to-folder/feature.server.ts
@@ -44,7 +44,7 @@ export const moveEntriesIntoSubfolder = async ({
 
   return {
     ok: true,
-    files: filesResult.status === "fulfilled" ? [filesResult.value] : [],
-    folders: foldersResult.status === "fulfilled" ? [foldersResult.value] : []
+    files: filesResult.status === "fulfilled" ? filesResult.value : [],
+    folders: foldersResult.status === "fulfilled" ? foldersResult.value : []
   }
 }

--- a/app/usecases/folder-explorer/move-to-folder/feature.server.ts
+++ b/app/usecases/folder-explorer/move-to-folder/feature.server.ts
@@ -1,6 +1,6 @@
 import * as TermService from "~/units/term/service.server"
 import * as FolderService from "~/units/folder/service.server"
-import type { MoveFailure, MoveSuccess } from "./types"
+import type { EntriesResults, MoveResult } from "./types"
 import { debugLog } from "~/libs/debug.server"
 
 interface MovePayload {
@@ -14,7 +14,7 @@ interface MovePayload {
 export const moveEntriesIntoSubfolder = async ({
   targets,
   newParentId
-}: MovePayload): Promise<MoveSuccess | MoveFailure> => {
+}: MovePayload): Promise<MoveResult> => {
   debugLog(targets)
 
   const results = await Promise.allSettled([
@@ -22,24 +22,24 @@ export const moveEntriesIntoSubfolder = async ({
     FolderService.moveFolders(targets.folder.ids, newParentId)
   ])
 
-  const rejected = results
-    .filter((r) => r.status === "rejected")
-    .map((r, i) => {
-      const type = i === 0 ? "file" : ("folder" as const)
-      const targetNames = type === "file" ? targets.file.names : targets.folder.names
-      return { reason: r.reason, type, names: targetNames } as const
-    })
+  const rejected = results.filter((r) => r.status === "rejected").length
+  const status = rejected === 0 ? "ALL_SUCCEEDED" : "HAS_FAILURES"
 
-  if (rejected.length > 0) {
-    console.error("Failed to move entries:", rejected)
-    return { ok: false, rejected }
-  }
-
-  const [filesResult, foldersResult] = results
+  const [files, folders] = results
+  const filesResult: EntriesResults = (() => {
+    const status = files.status === "fulfilled" ? "SUCCESS" : "FAILURE"
+    return { status, count: targets.file.ids.length, ...targets.file }
+  })()
+  const foldersResult: EntriesResults = (() => {
+    const status = folders.status === "fulfilled" ? "SUCCESS" : "FAILURE"
+    return { status, count: targets.folder.ids.length, ...targets.folder }
+  })()
 
   return {
-    ok: true,
-    files: filesResult.status === "fulfilled" ? filesResult.value : [],
-    folders: foldersResult.status === "fulfilled" ? foldersResult.value : []
+    status,
+    details: [
+      { type: "file", ...filesResult },
+      { type: "folder", ...foldersResult }
+    ]
   }
 }

--- a/app/usecases/folder-explorer/move-to-folder/feature.server.ts
+++ b/app/usecases/folder-explorer/move-to-folder/feature.server.ts
@@ -5,8 +5,8 @@ import { debugLog } from "~/libs/debug.server"
 
 interface MovePayload {
   targets: {
-    files: Map<number, string>
-    folders: Map<number, string>
+    file: { ids: number[]; names: string[] }
+    folder: { ids: number[]; names: string[] }
   }
   newParentId: number | null
 }
@@ -18,13 +18,13 @@ export const moveEntriesIntoSubfolder = async ({
   debugLog(targets)
 
   const results = await Promise.allSettled([
-    TermService.moveTerms([...targets.files.keys()], newParentId),
-    FolderService.moveFolders([...targets.folders.keys()], newParentId)
+    TermService.moveTerms(targets.file.ids, newParentId),
+    FolderService.moveFolders(targets.folder.ids, newParentId)
   ])
 
   const targetDetails = [
-    ...[...targets.files.values()].map((name) => ({ type: "file", name }) as const),
-    ...[...targets.folders.values()].map((name) => ({ type: "folder", name }) as const)
+    ...targets.file.names.map((name) => ({ type: "file", name }) as const),
+    ...targets.folder.names.map((name) => ({ type: "folder", name }) as const)
   ]
 
   const rejected = results

--- a/app/usecases/folder-explorer/move-to-folder/feature.server.ts
+++ b/app/usecases/folder-explorer/move-to-folder/feature.server.ts
@@ -1,0 +1,57 @@
+import * as TermService from "~/units/term/service.server"
+import * as FolderService from "~/units/folder/service.server"
+
+interface MovePayload {
+  targets: {
+    file: Map<number, { name: string; type: "file" }>[]
+    folder: Map<number, { name: string; type: "folder" }>[]
+  }
+  newParentId: number | null
+}
+
+interface MoveSuccess {
+  ok: true
+  files: { type: string; id: number; name: string }[]
+  folders: { type: string; id: number; name: string }[]
+}
+
+interface MoveFailure {
+  ok: false
+  rejected: { reason: any; name: string; type: "file" | "folder" }[]
+}
+
+export const moveEntriesIntoSubfolder = async ({
+  targets,
+  newParentId
+}: MovePayload): Promise<MoveSuccess | MoveFailure> => {
+  const results = await Promise.allSettled([
+    TermService.moveTerms([...targets.file.keys()], newParentId),
+    FolderService.moveFolders([...targets.folder.keys()], newParentId)
+  ])
+
+  const targetDetails = [
+    ...targets.file.flatMap((m) => [...m.values()]),
+    ...targets.folder.flatMap((m) => [...m.values()])
+  ]
+
+  const rejected = results
+    .flat()
+    .filter((r) => r.status === "rejected")
+    .map((r, i) => {
+      const target = targetDetails[i]
+      return { reason: r.reason, ...target }
+    })
+
+  if (rejected.length > 0) {
+    console.error("Failed to move entries:", rejected)
+    return { ok: false, rejected }
+  }
+
+  const [filesResult, foldersResult] = results
+
+  return {
+    ok: true,
+    files: filesResult.status === "fulfilled" ? [filesResult.value] : [],
+    folders: foldersResult.status === "fulfilled" ? [foldersResult.value] : []
+  }
+}

--- a/app/usecases/folder-explorer/move-to-folder/feature.server.ts
+++ b/app/usecases/folder-explorer/move-to-folder/feature.server.ts
@@ -22,17 +22,12 @@ export const moveEntriesIntoSubfolder = async ({
     FolderService.moveFolders(targets.folder.ids, newParentId)
   ])
 
-  const targetDetails = [
-    ...targets.file.names.map((name) => ({ type: "file", name }) as const),
-    ...targets.folder.names.map((name) => ({ type: "folder", name }) as const)
-  ]
-
   const rejected = results
-    .flat()
     .filter((r) => r.status === "rejected")
     .map((r, i) => {
-      const target = targetDetails[i]
-      return { reason: r.reason, ...target }
+      const type = i === 0 ? "file" : ("folder" as const)
+      const targetNames = type === "file" ? targets.file.names : targets.folder.names
+      return { reason: r.reason, type, names: targetNames } as const
     })
 
   if (rejected.length > 0) {

--- a/app/usecases/folder-explorer/move-to-folder/feature.server.ts
+++ b/app/usecases/folder-explorer/move-to-folder/feature.server.ts
@@ -1,5 +1,6 @@
 import * as TermService from "~/units/term/service.server"
 import * as FolderService from "~/units/folder/service.server"
+import type { MoveFailure, MoveSuccess } from "./types"
 
 interface MovePayload {
   targets: {
@@ -7,17 +8,6 @@ interface MovePayload {
     folder: Map<number, { name: string; type: "folder" }>[]
   }
   newParentId: number | null
-}
-
-interface MoveSuccess {
-  ok: true
-  files: { type: string; id: number; name: string }[]
-  folders: { type: string; id: number; name: string }[]
-}
-
-interface MoveFailure {
-  ok: false
-  rejected: { reason: any; name: string; type: "file" | "folder" }[]
 }
 
 export const moveEntriesIntoSubfolder = async ({

--- a/app/usecases/folder-explorer/move-to-folder/feature.server.ts
+++ b/app/usecases/folder-explorer/move-to-folder/feature.server.ts
@@ -1,11 +1,12 @@
 import * as TermService from "~/units/term/service.server"
 import * as FolderService from "~/units/folder/service.server"
 import type { MoveFailure, MoveSuccess } from "./types"
+import { debugLog } from "~/libs/debug.server"
 
 interface MovePayload {
   targets: {
-    file: Map<number, { name: string; type: "file" }>[]
-    folder: Map<number, { name: string; type: "folder" }>[]
+    files: Map<number, string>
+    folders: Map<number, string>
   }
   newParentId: number | null
 }
@@ -14,14 +15,16 @@ export const moveEntriesIntoSubfolder = async ({
   targets,
   newParentId
 }: MovePayload): Promise<MoveSuccess | MoveFailure> => {
+  debugLog(targets)
+
   const results = await Promise.allSettled([
-    TermService.moveTerms([...targets.file.keys()], newParentId),
-    FolderService.moveFolders([...targets.folder.keys()], newParentId)
+    TermService.moveTerms([...targets.files.keys()], newParentId),
+    FolderService.moveFolders([...targets.folders.keys()], newParentId)
   ])
 
   const targetDetails = [
-    ...targets.file.flatMap((m) => [...m.values()]),
-    ...targets.folder.flatMap((m) => [...m.values()])
+    ...[...targets.files.values()].map((name) => ({ type: "file", name }) as const),
+    ...[...targets.folders.values()].map((name) => ({ type: "folder", name }) as const)
   ]
 
   const rejected = results

--- a/app/usecases/folder-explorer/move-to-folder/types.ts
+++ b/app/usecases/folder-explorer/move-to-folder/types.ts
@@ -1,10 +1,11 @@
-export interface MoveSuccess {
-  ok: true
-  files: { id: number; name: string }[]
-  folders: { id: number; name: string }[]
+export type EntriesResults = {
+  status: "SUCCESS" | "FAILURE"
+  count: number
+  ids: number[]
+  names: string[]
 }
 
-export interface MoveFailure {
-  ok: false
-  rejected: { reason: any; type: "file" | "folder"; names: string[] }[]
+export type MoveResult = {
+  status: "ALL_SUCCEEDED" | "HAS_FAILURES"
+  details: Array<{ type: "file" | "folder" } & EntriesResults>
 }

--- a/app/usecases/folder-explorer/move-to-folder/types.ts
+++ b/app/usecases/folder-explorer/move-to-folder/types.ts
@@ -1,0 +1,10 @@
+export interface MoveSuccess {
+  ok: true
+  files: { type: string; id: number; name: string }[]
+  folders: { type: string; id: number; name: string }[]
+}
+
+export interface MoveFailure {
+  ok: false
+  rejected: { reason: any; name: string; type: "file" | "folder" }[]
+}

--- a/app/usecases/folder-explorer/move-to-folder/types.ts
+++ b/app/usecases/folder-explorer/move-to-folder/types.ts
@@ -1,7 +1,7 @@
 export interface MoveSuccess {
   ok: true
-  files: { type: string; id: number; name: string }[]
-  folders: { type: string; id: number; name: string }[]
+  files: { id: number; name: string }[]
+  folders: { id: number; name: string }[]
 }
 
 export interface MoveFailure {

--- a/app/usecases/folder-explorer/move-to-folder/types.ts
+++ b/app/usecases/folder-explorer/move-to-folder/types.ts
@@ -6,5 +6,5 @@ export interface MoveSuccess {
 
 export interface MoveFailure {
   ok: false
-  rejected: { reason: any; name: string; type: "file" | "folder" }[]
+  rejected: { reason: any; type: "file" | "folder"; names: string[] }[]
 }

--- a/app/usecases/folder-explorer/move-to-folder/ui.actions.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.actions.ts
@@ -25,6 +25,18 @@ export const updateFolderIdsToMove$ = atom(
   }
 )
 
+export const removeFileIdsToMove$ = atom(null, (get, set, fileIds: number[]) => {
+  const files = new Map(get(filesToMove$))
+  fileIds.forEach((id) => files.delete(id))
+  set(filesToMove$, files)
+})
+
+export const removeFolderIdsToMove$ = atom(null, (get, set, folderIds: number[]) => {
+  const folders = new Map(get(foldersToMove$))
+  folderIds.forEach((id) => folders.delete(id))
+  set(foldersToMove$, folders)
+})
+
 export const resetMovingModeState$ = atom(null, (_, set) => {
   set(filesToMove$, RESET)
   set(foldersToMove$, RESET)

--- a/app/usecases/folder-explorer/move-to-folder/ui.actions.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.actions.ts
@@ -1,29 +1,32 @@
 import { atom } from "jotai"
-import { destFolder$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
+import { destFolder$, filesToMove$, foldersToMove$ } from "./ui.atoms"
 import { RESET } from "jotai/utils"
 
-export const updateFileIdsToMove$ = atom(null, (get, set, fileId: number) => {
-  const fileIds = new Set(get(fileIdsToMove$))
-  if (fileIds.has(fileId)) {
-    fileIds.delete(fileId)
+export const updateFileIdsToMove$ = atom(null, (get, set, file: { id: number; name: string }) => {
+  const files = new Map(get(filesToMove$))
+  if (files.has(file.id)) {
+    files.delete(file.id)
   } else {
-    fileIds.add(fileId)
+    files.set(file.id, file.name)
   }
-  set(fileIdsToMove$, fileIds)
+  set(filesToMove$, files)
 })
 
-export const updateFolderIdsToMove$ = atom(null, (get, set, folderId: number) => {
-  const folderIds = new Set(get(folderIdsToMove$))
-  if (folderIds.has(folderId)) {
-    folderIds.delete(folderId)
-  } else {
-    folderIds.add(folderId)
+export const updateFolderIdsToMove$ = atom(
+  null,
+  (get, set, folder: { id: number; name: string }) => {
+    const folders = new Map(get(foldersToMove$))
+    if (folders.has(folder.id)) {
+      folders.delete(folder.id)
+    } else {
+      folders.set(folder.id, folder.name)
+    }
+    set(foldersToMove$, folders)
   }
-  set(folderIdsToMove$, folderIds)
-})
+)
 
 export const resetMovingModeState$ = atom(null, (_, set) => {
-  set(fileIdsToMove$, RESET)
-  set(folderIdsToMove$, RESET)
+  set(filesToMove$, RESET)
+  set(foldersToMove$, RESET)
   set(destFolder$, RESET)
 })

--- a/app/usecases/folder-explorer/move-to-folder/ui.actions.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.actions.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai"
-import { fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
+import { destinationFolderId$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
+import { RESET } from "jotai/utils"
 
 export const updateFileIdsToMove$ = atom(null, (get, set, fileId: number) => {
   const fileIds = new Set(get(fileIdsToMove$))
@@ -19,4 +20,10 @@ export const updateFolderIdsToMove$ = atom(null, (get, set, folderId: number) =>
     folderIds.add(folderId)
   }
   set(folderIdsToMove$, folderIds)
+})
+
+export const resetMovingModeState$ = atom(null, (_, set) => {
+  set(fileIdsToMove$, RESET)
+  set(folderIdsToMove$, RESET)
+  set(destinationFolderId$, RESET)
 })

--- a/app/usecases/folder-explorer/move-to-folder/ui.actions.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.actions.ts
@@ -1,5 +1,5 @@
 import { atom } from "jotai"
-import { destinationFolderId$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
+import { destFolder$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
 import { RESET } from "jotai/utils"
 
 export const updateFileIdsToMove$ = atom(null, (get, set, fileId: number) => {
@@ -25,5 +25,5 @@ export const updateFolderIdsToMove$ = atom(null, (get, set, folderId: number) =>
 export const resetMovingModeState$ = atom(null, (_, set) => {
   set(fileIdsToMove$, RESET)
   set(folderIdsToMove$, RESET)
-  set(destinationFolderId$, RESET)
+  set(destFolder$, RESET)
 })

--- a/app/usecases/folder-explorer/move-to-folder/ui.atoms.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.atoms.ts
@@ -3,5 +3,5 @@ import { atomWithReset } from "jotai/utils"
 type DestFolder = { id: number | null; name: string }
 export const destFolder$ = atomWithReset<DestFolder | null>(null)
 
-export const fileIdsToMove$ = atomWithReset<Set<number>>(new Set<number>())
-export const folderIdsToMove$ = atomWithReset<Set<number>>(new Set<number>())
+export const filesToMove$ = atomWithReset<Map<number, string>>(new Map<number, string>())
+export const foldersToMove$ = atomWithReset<Map<number, string>>(new Map<number, string>())

--- a/app/usecases/folder-explorer/move-to-folder/ui.atoms.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.atoms.ts
@@ -1,6 +1,7 @@
 import { atomWithReset } from "jotai/utils"
 
-export const destinationFolderId$ = atomWithReset<number | "root" | null>(null)
+type DestFolder = { id: number | null; name: string }
+export const destFolder$ = atomWithReset<DestFolder | null>(null)
 
 export const fileIdsToMove$ = atomWithReset<Set<number>>(new Set<number>())
 export const folderIdsToMove$ = atomWithReset<Set<number>>(new Set<number>())

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -6,12 +6,10 @@ import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/
 import type { MoveSuccess } from "./types"
 import { folderKeys, termKeys } from "~/query-keys"
 import { folderId$ } from "../ui.atoms"
+import { BatchActionError } from "~/libs/error"
 
 interface MoveSuccessResponse extends MoveSuccess {
   message: string
-}
-interface MoveFailureResponse {
-  errors: { message: string }[]
 }
 
 export const useMoveToFolderUi = (currentTermId: number) => {
@@ -26,7 +24,7 @@ export const useMoveToFolderUi = (currentTermId: number) => {
 
   const resetMovingModeState = useSetAtom(resetMovingModeState$)
 
-  const { mutate, isPending } = useMutation<MoveSuccessResponse, MoveFailureResponse>({
+  const { mutate, isPending } = useMutation<MoveSuccessResponse, BatchActionError>({
     mutationFn: () =>
       fetch("/api/entries/move", {
         method: "POST",
@@ -40,7 +38,7 @@ export const useMoveToFolderUi = (currentTermId: number) => {
         })
       }).then(async (res) => {
         const data = await res.json()
-        if (!res.ok) throw new Error(data.message || "Failed to move entries.")
+        if (!res.ok) throw new BatchActionError("Failed to move entries.", data)
         return data
       }),
     onSuccess: () => {
@@ -51,7 +49,7 @@ export const useMoveToFolderUi = (currentTermId: number) => {
     }
   })
 
-  const execMoveApi = (options: UseMutationOptions<MoveSuccessResponse, MoveFailureResponse>) => {
+  const execMoveApi = (options: UseMutationOptions<MoveSuccessResponse, BatchActionError>) => {
     if (destFolder === null) return
     mutate(void 0, options)
   }

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -1,16 +1,18 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { destFolder$, filesToMove$, foldersToMove$ } from "./ui.atoms"
-import { resetMovingModeState$, updateFileIdsToMove$, updateFolderIdsToMove$ } from "./ui.actions"
+import {
+  removeFileIdsToMove$,
+  removeFolderIdsToMove$,
+  resetMovingModeState$,
+  updateFileIdsToMove$,
+  updateFolderIdsToMove$
+} from "./ui.actions"
 import { isMovingMode$, selectedCount$ } from "./ui.selectors"
 import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/react-query"
-import type { MoveSuccess } from "./types"
 import { folderKeys, termKeys } from "~/query-keys"
 import { folderId$ } from "../ui.atoms"
 import { BatchActionError } from "~/libs/error"
-
-interface MoveSuccessResponse extends MoveSuccess {
-  message: string
-}
+import type { action } from "~/routes/api/entries/move"
 
 export const useMoveToFolderUi = (currentTermId: number) => {
   const queryClient = useQueryClient()
@@ -22,9 +24,12 @@ export const useMoveToFolderUi = (currentTermId: number) => {
 
   const [destFolder, setDestFolder] = useAtom(destFolder$)
 
+  const removeTargetFiles = useSetAtom(removeFileIdsToMove$)
+  const removeTargetFolders = useSetAtom(removeFolderIdsToMove$)
+
   const resetMovingModeState = useSetAtom(resetMovingModeState$)
 
-  const { mutate, isPending } = useMutation<MoveSuccessResponse, BatchActionError>({
+  const { mutate, isPending } = useMutation<Awaited<ReturnType<typeof action>>, BatchActionError>({
     mutationFn: () =>
       fetch("/api/entries/move", {
         method: "POST",
@@ -41,15 +46,23 @@ export const useMoveToFolderUi = (currentTermId: number) => {
         if (!res.ok) throw new BatchActionError("Failed to move entries.", data)
         return data
       }),
-    onSuccess: () => {
-      resetMovingModeState()
-      show(destFolder?.id ?? "root")
+    onSuccess: ({ errorsCount, success }) => {
+      if (errorsCount === 0) {
+        resetMovingModeState()
+        show(destFolder?.id ?? "root")
+      } else {
+        removeTargetFiles(success.file)
+        removeTargetFolders(success.folder)
+      }
+
       queryClient.invalidateQueries({ queryKey: folderKeys.details() })
       queryClient.invalidateQueries({ queryKey: termKeys.path(currentTermId) })
     }
   })
 
-  const execMoveApi = (options: UseMutationOptions<MoveSuccessResponse, BatchActionError>) => {
+  const execMoveApi = (
+    options: UseMutationOptions<Awaited<ReturnType<typeof action>>, BatchActionError>
+  ) => {
     if (destFolder === null) return
     mutate(void 0, options)
   }

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -5,6 +5,7 @@ import { isMovingMode$, selectedCount$ } from "./ui.selectors"
 import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/react-query"
 import type { MoveSuccess } from "./types"
 import { folderKeys } from "~/query-keys"
+import { folderId$ } from "../ui.atoms"
 
 interface MoveSuccessResponse extends MoveSuccess {
   message: string
@@ -15,6 +16,8 @@ interface MoveFailureResponse {
 
 export const useMoveToFolderUi = () => {
   const queryClient = useQueryClient()
+
+  const show = useSetAtom(folderId$)
 
   const targetFiles = useAtomValue(filesToMove$)
   const targetFolders = useAtomValue(foldersToMove$)
@@ -43,6 +46,7 @@ export const useMoveToFolderUi = () => {
     onSuccess: () => {
       resetMovingModeState()
 
+      show(destFolder?.id ?? "root")
       queryClient.invalidateQueries({ queryKey: folderKeys.details() })
 
       // TODO: エディタの上のパス文字列を更新

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -4,7 +4,7 @@ import { resetMovingModeState$, updateFileIdsToMove$, updateFolderIdsToMove$ } f
 import { isMovingMode$, selectedCount$ } from "./ui.selectors"
 import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/react-query"
 import type { MoveSuccess } from "./types"
-import { folderKeys } from "~/query-keys"
+import { folderKeys, termKeys } from "~/query-keys"
 import { folderId$ } from "../ui.atoms"
 
 interface MoveSuccessResponse extends MoveSuccess {
@@ -14,7 +14,7 @@ interface MoveFailureResponse {
   errors: { message: string }[]
 }
 
-export const useMoveToFolderUi = () => {
+export const useMoveToFolderUi = (currentTermId: number) => {
   const queryClient = useQueryClient()
 
   const show = useSetAtom(folderId$)
@@ -45,11 +45,9 @@ export const useMoveToFolderUi = () => {
       }),
     onSuccess: () => {
       resetMovingModeState()
-
       show(destFolder?.id ?? "root")
       queryClient.invalidateQueries({ queryKey: folderKeys.details() })
-
-      // TODO: エディタの上のパス文字列を更新
+      queryClient.invalidateQueries({ queryKey: termKeys.path(currentTermId) })
     }
   })
 

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -1,8 +1,43 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { destinationFolderId$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
-import { updateFileIdsToMove$, updateFolderIdsToMove$ } from "./ui.actions"
-import { useResetAtom } from "jotai/utils"
+import { resetMovingModeState$, updateFileIdsToMove$, updateFolderIdsToMove$ } from "./ui.actions"
 import { isMovingMode$, selectedCount$ } from "./ui.selectors"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+export const useMoveToFolderUi = () => {
+  const queryClient = useQueryClient()
+
+  const targetFileIds = useAtomValue(fileIdsToMove$)
+  const targetFolderIds = useAtomValue(folderIdsToMove$)
+
+  const newParentId = useAtomValue(destinationFolderId$)
+
+  const resetMovingModeState = useSetAtom(resetMovingModeState$)
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: () =>
+      fetch("/api/entries/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fileIds: Array.from(targetFileIds),
+          folderIds: Array.from(targetFolderIds),
+          newParentId
+        })
+      }).then(async (res) => {
+        const data = await res.json()
+        if (!res.ok) throw new Error(data.message || "Failed to move entries.")
+        return data
+      }),
+    onSuccess: () => {
+      resetMovingModeState()
+      queryClient.invalidateQueries({ queryKey: ["folders", "children"] })
+      // TODO: エディタの上のパス文字列を更新
+    }
+  })
+
+  return { execMoveApi: mutate, isMoving: isPending }
+}
 
 export const useMovingTargetFolderUi = () => {
   const [destinationFolderId, setDestinationFolderId] = useAtom(destinationFolderId$)
@@ -29,15 +64,7 @@ export const useMovingModeUi = () => {
   const isMovingMode = useAtomValue(isMovingMode$)
   const selectedCount = useAtomValue(selectedCount$)
 
-  const resetDestinationFolderId = useResetAtom(destinationFolderId$)
-  const resetFileIdsToMove = useResetAtom(fileIdsToMove$)
-  const resetFolderIdsToMove = useResetAtom(folderIdsToMove$)
-
-  const cancelMovingMode = () => {
-    resetDestinationFolderId()
-    resetFileIdsToMove()
-    resetFolderIdsToMove()
-  }
+  const cancelMovingMode = useSetAtom(resetMovingModeState$)
 
   return { cancelMovingMode, isMovingMode, selectedCount }
 }

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -17,7 +17,6 @@ export const useMoveToFolderUi = () => {
 
   const targetFiles = useAtomValue(filesToMove$)
   const targetFolders = useAtomValue(foldersToMove$)
-  console.log("targetFiles:", targetFiles)
 
   const [destFolder, setDestFolder] = useAtom(destFolder$)
 
@@ -30,8 +29,8 @@ export const useMoveToFolderUi = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           targets: {
-            files: targetFiles,
-            folders: targetFolders
+            file: { ids: [...targetFiles.keys()], names: [...targetFiles.values()] },
+            folder: { ids: [...targetFolders.keys()], names: [...targetFolders.values()] }
           },
           newParent: destFolder
         })
@@ -47,11 +46,15 @@ export const useMoveToFolderUi = () => {
     }
   })
 
+  const execMoveApi = (options: UseMutationOptions<MoveSuccessResponse, MoveFailureResponse>) => {
+    if (destFolder === null) return
+    mutate(void 0, options)
+  }
+
   return {
     destFolder,
     setDestFolder,
-    execMoveApi: (options: UseMutationOptions<MoveSuccessResponse, MoveFailureResponse>) =>
-      mutate(void 0, options),
+    execMoveApi,
     isMoving: isPending
   }
 }

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
-import { destinationFolderId$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
+import { destFolder$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
 import { resetMovingModeState$, updateFileIdsToMove$, updateFolderIdsToMove$ } from "./ui.actions"
 import { isMovingMode$, selectedCount$ } from "./ui.selectors"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
@@ -10,7 +10,7 @@ export const useMoveToFolderUi = () => {
   const targetFileIds = useAtomValue(fileIdsToMove$)
   const targetFolderIds = useAtomValue(folderIdsToMove$)
 
-  const newParentId = useAtomValue(destinationFolderId$)
+  const [destFolder, setDestFolder] = useAtom(destFolder$)
 
   const resetMovingModeState = useSetAtom(resetMovingModeState$)
 
@@ -22,7 +22,7 @@ export const useMoveToFolderUi = () => {
         body: JSON.stringify({
           fileIds: Array.from(targetFileIds),
           folderIds: Array.from(targetFolderIds),
-          newParentId
+          newParent: destFolder
         })
       }).then(async (res) => {
         const data = await res.json()
@@ -36,16 +36,7 @@ export const useMoveToFolderUi = () => {
     }
   })
 
-  return { execMoveApi: mutate, isMoving: isPending }
-}
-
-export const useMovingTargetFolderUi = () => {
-  const [destinationFolderId, setDestinationFolderId] = useAtom(destinationFolderId$)
-
-  return {
-    destinationFolderId,
-    setDestinationFolderId
-  }
+  return { destFolder, setDestFolder, execMoveApi: mutate, isMoving: isPending }
 }
 
 export const useCheckFolderToMoveUi = () => {

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
-import { destFolder$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
+import { destFolder$, filesToMove$, foldersToMove$ } from "./ui.atoms"
 import { resetMovingModeState$, updateFileIdsToMove$, updateFolderIdsToMove$ } from "./ui.actions"
 import { isMovingMode$, selectedCount$ } from "./ui.selectors"
 import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/react-query"
@@ -15,8 +15,9 @@ interface MoveFailureResponse {
 export const useMoveToFolderUi = () => {
   const queryClient = useQueryClient()
 
-  const targetFileIds = useAtomValue(fileIdsToMove$)
-  const targetFolderIds = useAtomValue(folderIdsToMove$)
+  const targetFiles = useAtomValue(filesToMove$)
+  const targetFolders = useAtomValue(foldersToMove$)
+  console.log("targetFiles:", targetFiles)
 
   const [destFolder, setDestFolder] = useAtom(destFolder$)
 
@@ -28,8 +29,10 @@ export const useMoveToFolderUi = () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          fileIds: Array.from(targetFileIds),
-          folderIds: Array.from(targetFolderIds),
+          targets: {
+            files: targetFiles,
+            folders: targetFolders
+          },
           newParent: destFolder
         })
       }).then(async (res) => {

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -2,7 +2,15 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { destFolder$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
 import { resetMovingModeState$, updateFileIdsToMove$, updateFolderIdsToMove$ } from "./ui.actions"
 import { isMovingMode$, selectedCount$ } from "./ui.selectors"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/react-query"
+import type { MoveSuccess } from "./types"
+
+interface MoveSuccessResponse extends MoveSuccess {
+  message: string
+}
+interface MoveFailureResponse {
+  errors: { message: string }[]
+}
 
 export const useMoveToFolderUi = () => {
   const queryClient = useQueryClient()
@@ -14,7 +22,7 @@ export const useMoveToFolderUi = () => {
 
   const resetMovingModeState = useSetAtom(resetMovingModeState$)
 
-  const { mutate, isPending } = useMutation({
+  const { mutate, isPending } = useMutation<MoveSuccessResponse, MoveFailureResponse>({
     mutationFn: () =>
       fetch("/api/entries/move", {
         method: "POST",
@@ -36,7 +44,13 @@ export const useMoveToFolderUi = () => {
     }
   })
 
-  return { destFolder, setDestFolder, execMoveApi: mutate, isMoving: isPending }
+  return {
+    destFolder,
+    setDestFolder,
+    execMoveApi: (options: UseMutationOptions<MoveSuccessResponse, MoveFailureResponse>) =>
+      mutate(void 0, options),
+    isMoving: isPending
+  }
 }
 
 export const useCheckFolderToMoveUi = () => {

--- a/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.hooks.ts
@@ -4,6 +4,7 @@ import { resetMovingModeState$, updateFileIdsToMove$, updateFolderIdsToMove$ } f
 import { isMovingMode$, selectedCount$ } from "./ui.selectors"
 import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/react-query"
 import type { MoveSuccess } from "./types"
+import { folderKeys } from "~/query-keys"
 
 interface MoveSuccessResponse extends MoveSuccess {
   message: string
@@ -41,7 +42,9 @@ export const useMoveToFolderUi = () => {
       }),
     onSuccess: () => {
       resetMovingModeState()
-      queryClient.invalidateQueries({ queryKey: ["folders", "children"] })
+
+      queryClient.invalidateQueries({ queryKey: folderKeys.details() })
+
       // TODO: エディタの上のパス文字列を更新
     }
   })

--- a/app/usecases/folder-explorer/move-to-folder/ui.selectors.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.selectors.ts
@@ -1,8 +1,8 @@
 import { atom } from "jotai"
-import { destinationFolderId$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
+import { destFolder$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
 
 export const isMovingMode$ = atom((get) => {
-  return get(destinationFolderId$) !== null
+  return get(destFolder$) !== null
 })
 
 export const selectedCount$ = atom((get) => {

--- a/app/usecases/folder-explorer/move-to-folder/ui.selectors.ts
+++ b/app/usecases/folder-explorer/move-to-folder/ui.selectors.ts
@@ -1,12 +1,12 @@
 import { atom } from "jotai"
-import { destFolder$, fileIdsToMove$, folderIdsToMove$ } from "./ui.atoms"
+import { destFolder$, filesToMove$, foldersToMove$ } from "./ui.atoms"
 
 export const isMovingMode$ = atom((get) => {
   return get(destFolder$) !== null
 })
 
 export const selectedCount$ = atom((get) => {
-  const fileIdsToMove = get(fileIdsToMove$)
-  const folderIdsToMove = get(folderIdsToMove$)
-  return fileIdsToMove.size + folderIdsToMove.size
+  const filesToMove = get(filesToMove$)
+  const foldersToMove = get(foldersToMove$)
+  return filesToMove.size + foldersToMove.size
 })


### PR DESCRIPTION
- [x] Atomにnameも持たせるようにする
- [x] エラーの場合の表示や挙動を確認
  - [x] fileは失敗し、folderが成功した場合などの状態の部分的な更新
  - [x] 成功時トーストでどれが成功したのかわかるようにする
- [x] loading中ボタンのスタイルをSaveButtonに合わせる
- 「Move Here」ボタンがクリックされたら、
  - [x] そのフォルダ配下に選択中のアイテムを移動する（API叩く）
  - [x] フォルダ内エントリ数を更新する
  - [x] そのフォルダ配下を表示するようにエクスプローラを切り替える
  - [x] 現在開いているノートのパスが変更された場合、エディタの上のパス文字列を更新する
- ~~`cd ..`ボタン右クリックでも同様に「親に移動するアイテムを選択」機能を実装~~
  - ~~まずはコンテキストメニューの実装から~~